### PR TITLE
Embrace the present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *~
 ebin/*.app
 src/purity_bifs.erl
+_build
 
 # Documentation related:
 doc/edoc-info

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ README.html
 
 # Byproducts of coredump script:
 *.{core,dump,labl}
+erl_crash.dump
+rebar3.crashdump
 
 # etags
 TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: erlang
+
+os:
+  - linux
+
+otp_release:
+   - 19.3
+   - 20.3
+   - 21.3
+   - 22.3
+   - 23.0
+
+script:
+  - rebar3 xref
+  - rebar3 dialyzer
+  - rebar3 tests
+  - rebar3 units

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ otp_release:
 script:
   - rebar3 xref
   - rebar3 dialyzer
-  - rebar3 tests
-  - rebar3 units
+  - make distclean ebin units
+  - make distclean ebin tests

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ VSN := $(PURITY_VSN)
 FILES := purity purity_utils purity_cli purity_plt purity_stats core_aliases cl_parser purity_bifs purity_hofs runtest
 SRC   := $(addsuffix .erl, $(FILES))
 BIN   := $(addprefix $(EBIN)/, $(addsuffix .beam, $(FILES)))
-CHEATS := predef/cheats predef/bifs predef/primops
+CHEATS := predef/cheats predef/bifs predef/primops scripts/purity_bifs
 
 APP_FILE := purity.app
 APP_SRC  := $(APP_FILE).src

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ $(EBIN)/%.beam: $(ESRC)/%.erl
 
 $(TEST)/%.beam: $(TEST)/%.erl
 	@echo "T  ERLC $<"
-	@$(ERLC) $(EFLAGS) -o $(dir $<) $<
+	@$(ERLC) $(EFLAGS) +nowarn_export_all -o $(dir $<) $<
 
 #.erl.beam:
 %.beam: %.erl

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ERLC ?= erlc
 DIALYZER ?= dialyzer
 
-EFLAGS += -DVSN='"$(VSN)"' +debug_info +warn_exported_vars +warn_unused_vars +warn_unused_import +warn_missing_spec
+EFLAGS += -DVSN='"$(VSN)"' +debug_info +warn_exported_vars +warn_unused_vars +warn_unused_import +nowarn_missing_spec
 DFLAGS += -n -Wunmatched_returns -Wunderspecs -Wrace_conditions -Wbehaviours
 
 ESRC ?= src

--- a/rebar.config
+++ b/rebar.config
@@ -24,3 +24,11 @@
 {pre_hooks, [
     {compile, "make src/purity_bifs.erl > /dev/null"}
 ]}.
+
+{edoc_opts, [
+    {preprocess, true},
+    {includes, ["src"]},
+    {macros, [{'VSN', 0.2}]},
+    {def, {vsn, "0.2"}},
+    {stylesheet, "style.css"}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{minimum_otp_vsn, "19.3"}.
+
 {erl_opts, [
     debug_info,
     warn_exported_vars,

--- a/rebar.config
+++ b/rebar.config
@@ -16,6 +16,12 @@
     ]}
 ]}.
 
+{xref_checks, [
+    undefined_function_calls,
+    locals_not_used,
+    deprecated_function_calls
+]}.
+
 {pre_hooks, [
     {compile, "make src/purity_bifs.erl > /dev/null"}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -34,3 +34,25 @@
     {def, {vsn, "0.2"}},
     {stylesheet, "style.css"}
 ]}.
+
+{profiles, [
+    {test, [
+        {erl_opts, [
+            nowarn_export_all
+        ]}
+    ]}
+]}.
+
+{plugins, [
+    {rebar_cmd, "0.2.5"}
+]}.
+
+{commands, [
+    {tests, ["make tests"]},
+    {units, ["make units"]}
+]}.
+
+{alias, [
+    {tests, [{cmd, "tests"}]},
+    {units, [{cmd, "units"}]}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,3 +15,7 @@
         behaviours
     ]}
 ]}.
+
+{pre_hooks, [
+    {compile, "make src/purity_bifs.erl > /dev/null"}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,17 @@
+{erl_opts, [
+    debug_info,
+    warn_exported_vars,
+    warn_unused_vars,
+    warn_unused_import,
+    nowarn_missing_spec,
+    {d, 'VSN', 0.2}
+]}.
+
+{dialyzer, [
+    {warnings, [
+        unmatched_returns,
+        underspecs,
+        race_conditions,
+        behaviours
+    ]}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -44,12 +44,12 @@
 ]}.
 
 {plugins, [
-    {rebar_cmd, "0.2.5"}
+    {rebar_cmd, "0.3.0"}
 ]}.
 
 {commands, [
-    {tests, "make tests"},
-    {units, "make units"}
+    {tests, "make distclean ebin tests", [{verbose, true}]},
+    {units, "make distclean ebin units", [{verbose, true}]}
 ]}.
 
 {alias, [

--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
     {warnings, [
         unmatched_returns,
         underspecs,
-        race_conditions,
-        behaviours
+        race_conditions
     ]}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -48,8 +48,8 @@
 ]}.
 
 {commands, [
-    {tests, ["make tests"]},
-    {units, ["make units"]}
+    {tests, "make tests"},
+    {units, "make units"}
 ]}.
 
 {alias, [

--- a/scripts/extract
+++ b/scripts/extract
@@ -31,7 +31,7 @@ def main(argv):
     with open(filename, 'rb') as fd:
         opts, data = extract(fd)
     for i, (k, v) in enumerate(data):
-        print write_tests(outfile(outdir, module, i), opts, k, v)
+        print (write_tests(outfile(outdir, module, i), opts, k, v))
     return 0
 
 def outfile(dir, mod, n):
@@ -41,7 +41,7 @@ def write_tests(filename, gopts, opts, data):
     assert not os.path.exists(filename), "file exists %r" % filename
     with open(filename, 'w') as fd:
         fd.write("{%s,\n" % merge_opts(gopts, opts))
-        data = ["{%s,%s}" % (f, v) for (f,v) in data.iteritems()]
+        data = ["{%s,%s}" % (f, v) for (f,v) in data.items()]
         fd.write(" [" + "\n ,".join(data) + "]}.\n")
     return filename
 
@@ -65,14 +65,14 @@ def merge_tests(tests):
     """Fill incomplete tests with the corresponding default test."""
     common = tests[None]
     keys = set(k for v in tests.values() for k in v.keys())
-    for k, v in tests.iteritems():
+    for k, v in tests.items():
         for k in keys:
             if k not in v and common: # Can't do anything if no common case exists.
                 v[k] = common[k]
     if not common:
         # Remove it, it was just created by the defaultdict.
         del tests[None]
-    return tuple(tests.iteritems())
+    return tuple(tests.items())
 
 def merge_opts(*opts):
     """Merge a list of option lists into a single option list."""
@@ -80,18 +80,18 @@ def merge_opts(*opts):
     return "[%s]" % (','.join(opt[1:-1] for opt in opts if opt))
 
 def is_test(text):
-    return "%<" in text
+    return "%<" in text.decode()
 
 def is_global(text):
     assert is_test(text)
-    return text.lstrip(" %<").startswith("global")
+    return text.decode().lstrip(" %<").startswith("global")
 
 def parse_global(text):
-    return text.replace("global", "").lstrip(" %<")
+    return text.decode().replace("global", "").lstrip(" %<")
 
 def parse_test(text):
     rgx = re.compile("(?:(\[[^]]*\])\s+)?([^ ]+)\s+(.+)\s*$")
-    return rgx.match(text.lstrip(' %<')).groups()
+    return rgx.match(text.decode().lstrip(' %<')).groups()
 
 def parse_fun(fun):
     """Convert fun/arity specifications to {module,fun,arity}."""

--- a/scripts/extract
+++ b/scripts/extract
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+# pylint: disable=missing-function-docstring
+
 """
 Extract expected test results from Erlang source files and write to
 separate files, grouped by option sets.
@@ -16,36 +18,35 @@ where:
 
 """
 
-import os.path, re, sys
+import os.path
+import re
+import sys
 from collections import defaultdict
 
-module = None
-
 def main(argv):
-    global module
     if len(argv) != 3:
-        print>>sys.stderr, "usage: %s <test_file> <output_directory>" % argv[0]
+        sys.stderr.write("usage: %s <test_file> <output_directory>" % argv[0])
         return 1
     filename, outdir = argv[1:]
-    module = os.path.basename(os.path.splitext(filename)[0])
-    with open(filename, 'rb') as fd:
-        opts, data = extract(fd)
-    for i, (k, v) in enumerate(data):
-        print (write_tests(outfile(outdir, module, i), opts, k, v))
+    mod0 = os.path.basename(os.path.splitext(filename)[0])
+    with open(filename, 'rb') as filedesc:
+        opts, data = extract(mod0, filedesc)
+    for datum, (key, value) in enumerate(data):
+        print(write_tests(outfile(outdir, mod0, datum), opts, key, value))
     return 0
 
-def outfile(dir, mod, n):
-    return os.path.join(dir, "%s.%s" % (mod, n))
+def outfile(folder, mod, datum):
+    return os.path.join(folder, "%s.%s" % (mod, datum))
 
 def write_tests(filename, gopts, opts, data):
     assert not os.path.exists(filename), "file exists %r" % filename
-    with open(filename, 'w') as fd:
-        fd.write("{%s,\n" % merge_opts(gopts, opts))
-        data = ["{%s,%s}" % (f, v) for (f,v) in data.items()]
-        fd.write(" [" + "\n ,".join(data) + "]}.\n")
+    with open(filename, 'w') as filedesc:
+        filedesc.write("{%s,\n" % merge_opts(gopts, opts))
+        data = ["{%s,%s}" % (fun, value) for (fun, value) in data.items()]
+        filedesc.write(" [" + "\n ,".join(data) + "]}.\n")
     return filename
 
-def extract(lines):
+def extract(mod0, lines):
     opts = None
     tests = defaultdict(dict)
     for line in lines:
@@ -56,7 +57,7 @@ def extract(lines):
                 opts = parse_global(line)
             else:
                 opt, fun, result = parse_test(line)
-                fun = parse_fun(fun)
+                fun = parse_fun(mod0, fun)
                 assert fun not in tests[opt], "duplicate test %r" % fun
                 tests[opt][fun] = result
     return opts, merge_tests(tests)
@@ -64,11 +65,11 @@ def extract(lines):
 def merge_tests(tests):
     """Fill incomplete tests with the corresponding default test."""
     common = tests[None]
-    keys = set(k for v in tests.values() for k in v.keys())
-    for k, v in tests.items():
-        for k in keys:
-            if k not in v and common: # Can't do anything if no common case exists.
-                v[k] = common[k]
+    keys = set(key for value in tests.values() for key in value.keys())
+    for _, value in tests.items():
+        for key in keys:
+            if key not in value and common: # Can't do anything if no common case exists.
+                value[key] = common[key]
     if not common:
         # Remove it, it was just created by the defaultdict.
         del tests[None]
@@ -90,16 +91,16 @@ def parse_global(text):
     return text.decode().replace("global", "").lstrip(" %<")
 
 def parse_test(text):
-    rgx = re.compile("(?:(\[[^]]*\])\s+)?([^ ]+)\s+(.+)\s*$")
+    rgx = re.compile(r"(?:(\[[^]]*\])\s+)?([^ ]+)\s+(.+)\s*$")
     return rgx.match(text.decode().lstrip(' %<')).groups()
 
-def parse_fun(fun):
-    """Convert fun/arity specifications to {module,fun,arity}."""
-    rgx = re.compile("(\w+|'[a-zA-Z0-9_-]+')/(\d)")
-    m = rgx.match(fun)
-    if m is not None:
-        f, a = m.groups()
-        return "{%s,%s,%s}" % (module,f, a)
+def parse_fun(mod0, fun):
+    """Convert fun/arity specifications to {mod0,fun,arity}."""
+    rgx = re.compile(r"(\w+|'[a-zA-Z0-9_-]+')/(\d)")
+    mod = rgx.match(fun)
+    if mod is not None:
+        fun, arity = mod.groups()
+        return "{%s,%s,%s}" % (mod0, fun, arity)
     return fun
 
 

--- a/scripts/purity_bifs
+++ b/scripts/purity_bifs
@@ -40,10 +40,10 @@ header() {
 
 %% Dialyzer complains of supertypes.
 %-spec is_pure(atom(), atom(), arity()) -> purity:pure() | unknown.
--spec is_known(atom(), atom(), arity()) -> boolean().
+%-spec is_known(atom(), atom(), arity()) -> boolean().
 
 %-spec is_pure(atom(), arity()) -> purity:pure() | unknown.
--spec is_known(atom(), arity()) -> boolean().
+%-spec is_known(atom(), arity()) -> boolean().
 
 EOF
 }

--- a/scripts/runtests
+++ b/scripts/runtests
@@ -23,7 +23,7 @@ runtest() { erl_exec runtest main $@ }
 passed() { ((P++)); rm $1 }
 failed() { ((F++)) }
 report() {
-    if ((F>0)); then echo "$F/$((P+F)) TESTS FAILED"
+    if ((F>0)); then echo "$F/$((P+F)) TESTS FAILED" ; exit 1
     else echo "ALL $P TESTS PASSED"; fi
 }
 

--- a/scripts/runtests
+++ b/scripts/runtests
@@ -13,7 +13,7 @@ main() {
             runtest $test $exp $dir && passed $exp || failed
         done
     done
-    rmdir $dir
+    rmdir --ignore-fail-on-non-empty $dir
     report
 
     extra_tests

--- a/scripts/utests
+++ b/scripts/utests
@@ -16,6 +16,7 @@ main(Tests) ->
     end.
 
 test(Filename) ->
+    true = code:add_path("ebin"),
     Module = list_to_atom(filename:rootname(filename:basename(Filename))),
     io:format("~s~n", [Module]),
     eunit:test({inparallel, Module}).

--- a/src/cl_parser.erl
+++ b/src/cl_parser.erl
@@ -40,10 +40,10 @@
 
 %% A reference to the finalized description in it's original form
 %% is preserved in `desc', for use with pretty_print/2.
--record(spec, {names    = dict:new() :: dict(),
-               types    = dict:new() :: dict(),
-               help     = dict:new() :: dict(),
-               defaults = dict:new() :: dict(),
+-record(spec, {names    = dict:new() :: dict:dict(),
+               types    = dict:new() :: dict:dict(),
+               help     = dict:new() :: dict:dict(),
+               defaults = dict:new() :: dict:dict(),
                desc     = []         :: desc()}).
 
 

--- a/src/core_aliases.erl
+++ b/src/core_aliases.erl
@@ -40,7 +40,7 @@
 %%   <cor1, cor2> when true -> match_fail'
 %% will produce a mapping of `{Pred, cor1}', `{List, cor2}' and `{cor3, cor2}'.
 
--spec scan(cerl:c_fun()) -> dict().
+-spec scan(cerl:c_fun()) -> dict:dict().
 
 scan(Fun) ->
     true = cerl:is_c_fun(Fun),
@@ -85,7 +85,7 @@ collect_aliases(Tree, VarMap) ->
 %% @doc Return a reverse mapping of the associative list KeyVals.
 %% Any elements which have multiple associations, are omitted.
 
--spec reverse_map([{name(), name()}]) -> dict().
+-spec reverse_map([{name(), name()}]) -> dict:dict().
 
 reverse_map(KeyVals) ->
     Acc = {dict:new(), []},
@@ -93,7 +93,7 @@ reverse_map(KeyVals) ->
     lists:foldl(fun(K, D) -> dict:erase(K, D) end, Dict, ToPurge).
 
 
--spec add_rev_unique({name(), name()}, {dict(), [name()]}) -> {dict(), [name()]}.
+-spec add_rev_unique({name(), name()}, {dict:dict(), [name()]}) -> {dict:dict(), [name()]}.
 
 add_rev_unique({Key, Key}, Acc) ->
     Acc;

--- a/src/purity.app.src
+++ b/src/purity.app.src
@@ -12,6 +12,6 @@
              core_aliases,
              cl_parser]},
   {registered, []},
-  {applications, [compiler, stdlib]},
+  {applications, [kernel, compiler, stdlib]},
   {env, []}]}.
 

--- a/src/purity.erl
+++ b/src/purity.erl
@@ -175,7 +175,7 @@ load_plt_silent(Opts) ->
 
 %% State record for propagation of dependency lists to pureness values.
 -record(pst, {funs = []         :: [mfa()],
-              prev = sets:new() :: set(),
+              prev = sets:new() :: sets:set(),
               revs              :: dict:dict(),
               rsns = false      :: boolean(),
               cycles            :: dict:dict(),

--- a/src/purity.erl
+++ b/src/purity.erl
@@ -71,7 +71,7 @@
 -type map_val() :: mfa() | pos_integer().
 -type map()     :: [{map_key(), map_val()}].
 
--type sub() :: {dict(), dict()}.
+-type sub() :: {dict:dict(), dict:dict()}.
 
 -type pure()    :: true
                  | false | {false, string() | binary()}
@@ -79,11 +79,11 @@
                  | undefined.
 
 
-%% @spec is_pure(mfa(), dict()) -> boolean()
+%% @spec is_pure(mfa(), dict:dict()) -> boolean()
 %%
 %% @doc Simple purity test, only distinguishes between pure and impure.
 %% Any function missing from the lookup table is also considered impure.
--spec is_pure(mfa(), dict()) -> boolean().
+-spec is_pure(mfa(), dict:dict()) -> boolean().
 
 is_pure({_,_,_} = MFA, Table) ->
     case dict:find(MFA, Table) of
@@ -93,7 +93,7 @@ is_pure({_,_,_} = MFA, Table) ->
             false
     end.
 
-%% @spec module(cerl:c_module(), purity_utils:options()) -> dict()
+%% @spec module(cerl:c_module(), purity_utils:options()) -> dict:dict()
 %%
 %% @doc Analyse a module and return a lookup table of concrete results,
 %% indexed by `{Module, Function, Arity}'.
@@ -103,7 +103,7 @@ is_pure({_,_,_} = MFA, Table) ->
 %% @see is_pure/2
 %% @see module/3
 %% @see propagate/2
--spec module(cerl:c_module(), purity_utils:options()) -> dict().
+-spec module(cerl:c_module(), purity_utils:options()) -> dict:dict().
 
 module(Core, Options) ->
     Plt = load_plt_silent(Options),
@@ -162,13 +162,13 @@ load_plt_silent(Opts) ->
                 vars    = map_new()  :: map(),
                 args    = map_new()  :: map(),
                 subs    = sub_new()  :: sub(),
-                aliases = dict:new() :: dict(),
+                aliases = dict:new() :: dict:dict(),
                 free    = []         :: [cerl:var_name()],
                 nested  = []         :: [mfa()],
                 count   = 1          :: pos_integer(),
                 names   = []         :: [atom()],
                 opts    = []         :: [any()],
-                table   = dict:new() :: dict()}).
+                table   = dict:new() :: dict:dict()}).
 
 -type state() :: #state{}.
 
@@ -176,16 +176,16 @@ load_plt_silent(Opts) ->
 %% State record for propagation of dependency lists to pureness values.
 -record(pst, {funs = []         :: [mfa()],
               prev = sets:new() :: set(),
-              revs              :: dict(),
+              revs              :: dict:dict(),
               rsns = false      :: boolean(),
-              cycles            :: dict(),
-              table             :: dict()}).
+              cycles            :: dict:dict(),
+              table             :: dict:dict()}).
 
 
 %% @doc Return a list of MFAs and a list of primops for which we have no
 %% pureness information.
 
--spec find_missing(dict()) -> {[mfa()], [purity_utils:primop()]}.
+-spec find_missing(dict:dict()) -> {[mfa()], [purity_utils:primop()]}.
 
 find_missing(Table) ->
     Set1 = ordsets:from_list(collect_function_deps(Table)),
@@ -252,7 +252,7 @@ make_modlookup(Filenames) ->
     fun(Mod) -> dict:find(Mod, Map) end.
 
 
-%% @spec module(cerl:c_module(), options(), dict()) -> dict()
+%% @spec module(cerl:c_module(), options(), dict:dict()) -> dict:dict()
 %%
 %% @doc Analyse a module and return a lookup table of functions
 %% and dependencies, indexed by `{Module, Function, Arity}'.
@@ -261,7 +261,7 @@ make_modlookup(Filenames) ->
 %%
 %% @see modules/3
 
--spec module(cerl:c_module(), purity_utils:options(), dict()) -> dict().
+-spec module(cerl:c_module(), purity_utils:options(), dict:dict()) -> dict:dict().
 
 module(Core, Options, Tab0) ->
     Module = cerl:concrete(cerl:module_name(Core)),
@@ -288,7 +288,7 @@ module(Core, Options, Tab0) ->
 %%
 %% @see module/3
 
--spec modules([string()], purity_utils:options(), dict()) -> dict().
+-spec modules([string()], purity_utils:options(), dict:dict()) -> dict:dict().
 
 modules(Modules, Options, Tab0) when is_list(Modules) ->
     lists:foldl(
@@ -310,7 +310,7 @@ modules(Modules, Options, Tab0) when is_list(Modules) ->
 %% @see module/3
 %% @see modules/3
 
--spec pmodules([file:filename()], purity_utils:options(), dict()) -> dict().
+-spec pmodules([file:filename()], purity_utils:options(), dict:dict()) -> dict:dict().
 
 pmodules(Modules, Options, Tab0) when is_list(Modules) ->
     CPUs = erlang:system_info(logical_processors),
@@ -344,7 +344,7 @@ ungroup(Tab) ->
               dict:new(), Tab).
 
 
--spec panalyse(file:filename(), purity_utils:options()) -> dict().
+-spec panalyse(file:filename(), purity_utils:options()) -> dict:dict().
 
 panalyse(Filename, Options) ->
     Tab = dict:new(),
@@ -996,7 +996,7 @@ sub_new() -> {dict:new(), dict:new()}.
 %% @see propagate_purity/2
 %% @see propagate_termination/2
 
--spec propagate(dict(), purity_utils:options()) -> dict().
+-spec propagate(dict:dict(), purity_utils:options()) -> dict:dict().
 
 propagate(Tab, Opts) ->
     case option(both, Opts) of
@@ -1015,7 +1015,7 @@ propagate(Tab, Opts) ->
 %% @doc Combine the propagation into one function, which is
 %% significantly faster. First perform an impure purity propagation,
 %% and then run the termination analysis.
--spec propagate_both(dict(), purity_utils:options()) -> dict().
+-spec propagate_both(dict:dict(), purity_utils:options()) -> dict:dict().
 
 propagate_both(Tab0, Opts) ->
     Tab1 = merge(add_bifs(Tab0), dict:from_list(?PREDEF)),
@@ -1057,7 +1057,7 @@ collect_impure(F, V, A) ->
 %% cases of functions which consume one of their arguments are
 %% also detected and considered terminating.
 
--spec propagate_termination(dict(), purity_utils:options()) -> dict().
+-spec propagate_termination(dict:dict(), purity_utils:options()) -> dict:dict().
 
 propagate_termination(Tab0, Opts) ->
     %% All BIFs are considered terminating, but we have to keep track
@@ -1088,7 +1088,7 @@ recursive_functions(Tab) ->
     [F || C <- digraph_utils:cyclic_strong_components(dependency_graph(Tab)),
           F <- C].
 
-%% @spec propagate_purity(dict(), purity_utils:options()) -> dict()
+%% @spec propagate_purity(dict:dict(), purity_utils:options()) -> dict:dict()
 %%
 %% @doc Return a version of the lookup table with dependencies
 %% converted to concrete results.
@@ -1100,7 +1100,7 @@ recursive_functions(Tab) ->
 %% @see module/3
 %% @see modules/3
 
--spec propagate_purity(dict(), purity_utils:options()) -> dict().
+-spec propagate_purity(dict:dict(), purity_utils:options()) -> dict:dict().
 
 propagate_purity(Tab0, Opts) ->
     Vs =
@@ -1254,7 +1254,7 @@ converge_pst(Fun, #pst{table = Tab} = St0) ->
             converge_pst(Fun, St1)
     end.
 
-%% @doc Return two lists of functions with concrete values, one for 
+%% @doc Return two lists of functions with concrete values, one for
 %% pure and one for impure ones.
 collect_concrete(Tab) ->
     dict:fold(fun collect_concrete/3, {[], []}, Tab).

--- a/src/purity.erl
+++ b/src/purity.erl
@@ -69,7 +69,7 @@
 
 -type map_key() :: cerl:var_name().
 -type map_val() :: mfa() | pos_integer().
--type map()     :: [{map_key(), map_val()}].
+-type kv_map()  :: [{map_key(), map_val()}].
 
 -type sub() :: {dict:dict(), dict:dict()}.
 
@@ -159,8 +159,8 @@ load_plt_silent(Opts) ->
 %%            value or a context.
 -record(state, {mfa     = undefined  :: mfa() | undefined,
                 ctx     = ctx_new()  :: [context()],
-                vars    = map_new()  :: map(),
-                args    = map_new()  :: map(),
+                vars    = map_new()  :: kv_map(),
+                args    = map_new()  :: kv_map(),
                 subs    = sub_new()  :: sub(),
                 aliases = dict:new() :: dict:dict(),
                 free    = []         :: [cerl:var_name()],
@@ -948,11 +948,11 @@ lookup_arg(Name, #state{args = ArgMap} = St) ->
 map_new() ->
     [].
 
--spec map_add(map_key(), map_val(), map()) -> map().
+-spec map_add(map_key(), map_val(), kv_map()) -> kv_map().
 map_add(Key, Val, Map) ->
     [{Key, Val}|Map].
 
--spec map_lookup(map_key(), map()) -> error | {ok, map_val()}.
+-spec map_lookup(map_key(), kv_map()) -> error | {ok, map_val()}.
 map_lookup(Key, Map) ->
     case lists:keyfind(Key, 1, Map) of
         false ->

--- a/src/purity.erl
+++ b/src/purity.erl
@@ -178,7 +178,7 @@ load_plt_silent(Opts) ->
               prev = sets:new() :: sets:set(),
               revs              :: dict:dict(),
               rsns = false      :: boolean(),
-              cycles            :: dict:dict(),
+              cycles            :: undefined | dict:dict(),
               table             :: dict:dict()}).
 
 

--- a/src/purity_cli.erl
+++ b/src/purity_cli.erl
@@ -264,7 +264,7 @@ pretty_print(Print, {MFA, Result}) ->
     Print("~s ~s.~n", [fmt_mfa(MFA), fmt(Result)]).
 
 
--spec print_missing(fun((_,_) -> ok), dict()) -> ok.
+-spec print_missing(fun((_,_) -> ok), dict:dict()) -> ok.
 
 print_missing(Print, Table) ->
     {Funs, Primops} = purity:find_missing(Table),

--- a/src/purity_cli.erl
+++ b/src/purity_cli.erl
@@ -82,13 +82,13 @@ main() ->
     Print = case option(output, Options) of
         false ->
             fun io:format/2;
-        Filename ->
-            case file:open(Filename, [write]) of
+        Filename0 ->
+            case file:open(Filename0, [write]) of
                 {ok, Io} ->
                     fun(Fmt, Args) -> io:format(Io, Fmt, Args) end;
                 {error, Reason} ->
                     io:format("Could not open file ~p for writing (~p)~n", [
-                            Filename, Reason]),
+                            Filename0, Reason]),
                     fun io:format/2
             end
     end,

--- a/src/purity_hofs.erl
+++ b/src/purity_hofs.erl
@@ -37,7 +37,7 @@
 
 -record(lst, {tab                   :: dict:dict(),
               rev                   :: dict:dict(),
-              graph                 :: digraph(),
+              graph                 :: digraph:graph(),
               closed = sets:new()   :: sets:set()}).
 
 
@@ -46,7 +46,7 @@
 %% argument is expected. Vertices are MFAs while edges are labeled with the
 %% a {From, To} tuple regarding the argument in question.
 %% Limited to functions with a single function as argument at the moment.
--spec make_arg_graph(dict:dict(), dict:dict()) -> digraph().
+-spec make_arg_graph(dict:dict(), dict:dict()) -> digraph:graph().
 make_arg_graph(Table, Reverse) ->
     Graph = digraph:new([acyclic]),
     %% The initial set of functions are those which directly
@@ -144,7 +144,7 @@ ctx_get_args(Ctx, {_,_,_} = Fun) when is_list(Ctx) ->
 %% This should produce the following graph:
 %%   F2 --1--> F1
 %% Which can be used to resolve the purity of F3 to pure.
--spec test_make_arg_graph() -> {dict:dict(), digraph()}.
+-spec test_make_arg_graph() -> {dict:dict(), digraph:graph()}.
 test_make_arg_graph() ->
     F1 = {m,f1,3},
     F2 = {m,f2,3},
@@ -162,7 +162,7 @@ test_make_arg_graph() ->
 %%% === Analysis === %%%
 
 -type resolution() :: {resolved, pure | impure} | unresolved.
--spec higher_analysis(mfa(), term(), dict:dict(), digraph()) -> resolution().
+-spec higher_analysis(mfa(), term(), dict:dict(), digraph:graph()) -> resolution().
 
 higher_analysis(_Fun, [{_Type, {_,_,_} = Dep, [{N, {_,_,_} = Arg}]}], Table, G) ->
     case dict:find(Dep, Table) of
@@ -272,7 +272,7 @@ test_higher_analysis() ->
 
 %% @doc Write a representation of the specified graph in the
 %% dot language, suitable for processing with graphviz.
--spec to_dot(digraph(), file:filename()) -> ok.
+-spec to_dot(digraph:graph(), file:filename()) -> ok.
 
 to_dot(Graph, Filename) ->
     hipe_dot:translate_digraph(Graph, Filename, "ArgGraph",

--- a/src/purity_hofs.erl
+++ b/src/purity_hofs.erl
@@ -35,8 +35,8 @@
 %%% on such `indirecty' higher order functions.
 %%%
 
--record(lst, {tab                   :: dict(),
-              rev                   :: dict(),
+-record(lst, {tab                   :: dict:dict(),
+              rev                   :: dict:dict(),
               graph                 :: digraph(),
               closed = sets:new()   :: set()}).
 
@@ -46,7 +46,7 @@
 %% argument is expected. Vertices are MFAs while edges are labeled with the
 %% a {From, To} tuple regarding the argument in question.
 %% Limited to functions with a single function as argument at the moment.
--spec make_arg_graph(dict(), dict()) -> digraph().
+-spec make_arg_graph(dict:dict(), dict:dict()) -> digraph().
 make_arg_graph(Table, Reverse) ->
     Graph = digraph:new([acyclic]),
     %% The initial set of functions are those which directly
@@ -144,7 +144,7 @@ ctx_get_args(Ctx, {_,_,_} = Fun) when is_list(Ctx) ->
 %% This should produce the following graph:
 %%   F2 --1--> F1
 %% Which can be used to resolve the purity of F3 to pure.
--spec test_make_arg_graph() -> {dict(), digraph()}.
+-spec test_make_arg_graph() -> {dict:dict(), digraph()}.
 test_make_arg_graph() ->
     F1 = {m,f1,3},
     F2 = {m,f2,3},
@@ -162,7 +162,7 @@ test_make_arg_graph() ->
 %%% === Analysis === %%%
 
 -type resolution() :: {resolved, pure | impure} | unresolved.
--spec higher_analysis(mfa(), term(), dict(), digraph()) -> resolution().
+-spec higher_analysis(mfa(), term(), dict:dict(), digraph()) -> resolution().
 
 higher_analysis(_Fun, [{_Type, {_,_,_} = Dep, [{N, {_,_,_} = Arg}]}], Table, G) ->
     case dict:find(Dep, Table) of

--- a/src/purity_hofs.erl
+++ b/src/purity_hofs.erl
@@ -38,7 +38,7 @@
 -record(lst, {tab                   :: dict:dict(),
               rev                   :: dict:dict(),
               graph                 :: digraph(),
-              closed = sets:new()   :: set()}).
+              closed = sets:new()   :: sets:set()}).
 
 
 %% @doc Build a directed graph representing calls to higher order functions,

--- a/src/purity_plt.erl
+++ b/src/purity_plt.erl
@@ -42,9 +42,9 @@
 
 -record(plt, {version   = ?VERSION   :: string(),
               checksums = []         :: [file_cksum()],
-              mod_deps  = dict:new() :: dict(),
-              table     = dict:new() :: dict(),
-              cache     = []         :: [{term(), dict()}]}).
+              mod_deps  = dict:new() :: dict:dict(),
+              table     = dict:new() :: dict:dict(),
+              cache     = []         :: [{term(), dict:dict()}]}).
 
 -opaque plt() :: #plt{}.
 
@@ -55,7 +55,7 @@ new() ->
     #plt{}.
 
 
--spec new(dict(), files()) -> plt().
+-spec new(dict:dict(), files()) -> plt().
 
 new(Table, Filenames) ->
     Checksums = compute_checksums(absolute(Filenames)),
@@ -66,7 +66,7 @@ new(Table, Filenames) ->
 absolute(Filenames) ->
     [filename:absname(F) || F <- Filenames].
 
--spec get_table(plt()) -> dict().
+-spec get_table(plt()) -> dict:dict().
 
 get_table(#plt{table = Table}) ->
     Table.
@@ -74,7 +74,7 @@ get_table(#plt{table = Table}) ->
 
 %% @doc Return the cached version of the table, falling back to the
 %% original one if no cache is found.
--spec get_cache(plt(), purity_utils:options()) -> dict().
+-spec get_cache(plt(), purity_utils:options()) -> dict:dict().
 
 get_cache(#plt{table = Tab, cache = Cache}, Options) ->
     case assoc_find(cache_key(Options), Cache) of
@@ -216,7 +216,7 @@ compute_checksum(Filename) ->
 %% they could have been analysed. This could be because they were
 %% e.g. deleted between the call to analysis and the call to update.
 %% Any module we can't checksum is therefore removed from both tables.
--spec update(plt(), files(), dict(), dict(), purity_utils:options()) -> plt().
+-spec update(plt(), files(), dict:dict(), dict:dict(), purity_utils:options()) -> plt().
 
 update(Plt, ExtraFiles0, Table0, Final0, Options) ->
     #plt{cache = Cache0, checksums = Checksums0, mod_deps = MD0} = Plt,

--- a/src/purity_stats.erl
+++ b/src/purity_stats.erl
@@ -38,7 +38,7 @@
 -type mod_stats() :: {module(), stats()}.
 
 %% @doc Generate an assoc list of modules and their statistics.
--spec gather([module()], dict()) -> [mod_stats()].
+-spec gather([module()], dict:dict()) -> [mod_stats()].
 
 gather(Modules, Table) ->
     Ms = sets:from_list(Modules),

--- a/src/purity_utils.erl
+++ b/src/purity_utils.erl
@@ -73,7 +73,7 @@ is_not_arg(_) ->
 %% @doc Return a mapping of modules to a list of modules that
 %% may have dependencies on them.
 
--spec rev_mod_deps(dict()) -> dict().
+-spec rev_mod_deps(dict:dict()) -> dict:dict().
 
 rev_mod_deps(Table) ->
     dict:map(
@@ -91,7 +91,7 @@ rev_mod_deps(_NonMFA, _Val, Deps) ->
 
 %% @doc Return a mapping of functions or primops to a list of
 %% functions their purity depends on.
--spec rev_deps(dict()) -> dict().
+-spec rev_deps(dict:dict()) -> dict:dict().
 
 rev_deps(Table) ->
     dict:map(
@@ -183,7 +183,7 @@ is_special(_) ->
 
 %% Faster than dict:append, in case order is not important.
 
--spec dict_cons(term(), term(), dict()) -> dict().
+-spec dict_cons(term(), term(), dict:dict()) -> dict:dict().
 
 dict_cons(Key, Val, Dict) ->
     dict:update(Key, fun(Old) -> [Val|Old] end, [Val], Dict).
@@ -279,7 +279,7 @@ fmt_mfa({F, A}) ->
 
 %% @doc Remove any functions belonging to Modules from the Table.
 
--spec delete_modules(dict(), [module()]) -> dict().
+-spec delete_modules(dict:dict(), [module()]) -> dict:dict().
 
 delete_modules(Table, []) ->
     Table;

--- a/test/combined_analysis
+++ b/test/combined_analysis
@@ -5,6 +5,7 @@
 %% both analyses separately and combining the results.
 
 main(Files) ->
+    true = code:add_path("ebin"),
     Tab = purity:modules(Files, [], dict:new()),
     lists:foreach(
         fun(L) ->

--- a/test/duplicates
+++ b/test/duplicates
@@ -5,6 +5,7 @@
 %% as running it sequentially.
 
 main(Files) ->
+    true = code:add_path("ebin"),
     T1 = purity:modules(Files, [], dict:new()),
     T2 = purity:pmodules(Files, [], dict:new()),
     lists:foreach(


### PR DESCRIPTION
Related to, and briefly discussed in inaka/elvis#95.

What is the current state here:
1. `purity` was "modernized" to work with Erlang/OTP 19.3, 20.3, 21.3, 22.3 and ~23.0~ 23.1,
2. this was done using `rebar3` (I added a `rebar.config` to ease maintenance), with most of the stuff in it "ported" from the `Makefile` - the `Makefile` was also a bit "modernized",
3. I didn't touch anything that wasn't in the way of having the content of `.travis.yml` running, i.e. my one focus was to get those elements executing properly (even if this means that some tests are failing, and were not fixed),
4. I added a `.travis.yml` file to allow for repeatability in testing,
5. I know there's a `dev` branch (and could eventually port my changes there, if it made sense), but it showed `dialyzer` issues (like calls to missing functions) and that "scared me away" a little,
6. in OTP 19 and 20, 1 test fails,
7. in OTP 21 and 22, 4 tests fail,
8, in OTP 23, 7 tests fail.

I wanted to update the lib. to be able to use it, but don't necessarily need to know all about its internals right away (which is why I didn't try to fix any of the failing tests). Some guidance and/or help, here, would be much appreciated.

**Edit**: what's missing?
1. `warn_missing_spec` on `erl_opts`, 
2. un-revert `-spec` changes from `scripts/purity_bifs`, 
3. have `make tests` clean - i.e. all tests passed.